### PR TITLE
fix: glob is not devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "eslint": "^6.7.1",
     "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-prettier": "^3.1.0",
-    "glob": "^7.1.6",
     "jest": "^24.8.0",
     "prettier": "^1.17.1",
     "rimraf": "^3.0.0",
@@ -65,6 +64,7 @@
   "dependencies": {
     "@microsoft/tsdoc": "^0.12.16",
     "catacli": "^0.1.3",
+    "glob": "^7.1.6",
     "source-map-support": "^0.5.12",
     "tsutils": "^3.17.1"
   }


### PR DESCRIPTION
I have occurred an error.
```
$ npx tsdoc-testify
Cannot find module 'glob'
Require stack:
- /Users/orisano/tmp/test/node_modules/tsdoc-testify/lib/cli.js
```